### PR TITLE
Ci update

### DIFF
--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7', '9.0.2', '9.2', '9.4', '9.6']
-        cabal: ['3.8']
+        ghc: ['9.2', '9.4', '9.6']
+        cabal: ['3.10']
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macOS-latest']
 
     steps:

--- a/.github/workflows/cabal-ci.yaml
+++ b/.github/workflows/cabal-ci.yaml
@@ -14,7 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.2', '9.4', '9.6']
+        ghc:
+        - '9.2'
+        - '9.6'
+        # - '9.4' currently not supported because of https://gitlab.haskell.org/ghc/ghc/-/issues/23972
         cabal: ['3.10']
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macOS-latest']
 

--- a/ethereum.cabal
+++ b/ethereum.cabal
@@ -28,6 +28,14 @@ flag openssl-use-pkg-config
     default: False
     manual: True
 
+-- Ethereum is now a PoS system. The implementation of the old PoW algorithm
+-- in this package is now deprecated and will be removed in the future.
+--
+flag ethhash
+    description: Include implementation Ethereum's old PoW hashing algorithm
+    default: False
+    manual: True
+
 common openssl-common
     c-sources:
         , cbits/prime.c
@@ -105,9 +113,6 @@ library
         -Wall
     exposed-modules:
         , Ethereum.Block
-        , Ethereum.Ethhash
-        , Ethereum.Ethhash.CacheSizes
-        , Ethereum.Ethhash.DataSizes
         , Ethereum.HP
         , Ethereum.HP.Internal
         , Ethereum.Header
@@ -135,6 +140,12 @@ library
         , unordered-containers >=0.2
         , vector >=0.12
 
+    if flag(ethhash)
+        exposed-modules:
+            , Ethereum.Ethhash
+            , Ethereum.Ethhash.CacheSizes
+            , Ethereum.Ethhash.DataSizes
+
 test-suite ethereum-tests
     import: openssl-common
     type: exitcode-stdio-1.0
@@ -142,7 +153,6 @@ test-suite ethereum-tests
     hs-source-dirs: test
     other-modules:
         , Test.Ethereum.Block
-        , Test.Ethereum.Ethhash
         , Test.Ethereum.HP
         -- , Test.Ethereum.Header
         , Test.Ethereum.RLP
@@ -162,15 +172,24 @@ test-suite ethereum-tests
         , base >=4.11 && <5
         , base16-bytestring >=0.1
         , bytestring >=0.10
-        , deepseq >=1.4
         , quickcheck-instances >=0.3
         , raw-strings-qq >=1.1
         , tasty >=1.3
         , tasty-hunit >=0.10
         , tasty-quickcheck >=0.10
-        , text >=1.2
+    if flag(ethhash)
+        cpp-options: -DETHHASH
+        other-modules:
+            , Test.Ethereum.Ethhash
+        build-depends:
+            , deepseq >=1.4
+            , text >=1.2
 
 benchmark ethhash
+    if flag(ethhash)
+        buildable: True
+    else
+        buildable: False
     import: openssl-common
     type: exitcode-stdio-1.0
     default-language: Haskell2010

--- a/ethereum.cabal
+++ b/ethereum.cabal
@@ -122,7 +122,7 @@ library
         , Numeric.Checked
     build-depends:
         , base >=4.11 && <5
-        , aeson >=1.4.5
+        , aeson >=1.4.5 && <2.2
         , base16-bytestring >=0.1
         , binary >=0.8
         , bytestring >=0.10
@@ -158,7 +158,7 @@ test-suite ethereum-tests
     build-depends:
         , ethereum
         , QuickCheck >=2.14
-        , aeson >=1.4.5
+        , aeson >=1.4.5 && <2.2
         , base >=4.11 && <5
         , base16-bytestring >=0.1
         , bytestring >=0.10

--- a/ethereum.cabal
+++ b/ethereum.cabal
@@ -11,10 +11,9 @@ maintainer: lakuhtz@gmail.com
 copyright: Copyright (c) 2020-2023 Kadena LLC.
 category: Data
 tested-with:
-    , GHC==9.4.2
-    , GHC==9.2.4
-    , GHC==9.0.2
-    , GHC==8.10.7
+    , GHC==9.6.2
+    -- , GHC 9.4.7 -- currently not supported because of https://gitlab.haskell.org/ghc/ghc/-/issues/23972
+    , GHC==9.2.8
 extra-source-files:
     , README.md
     , CHANGELOG.md

--- a/src/Ethereum/Transaction.hs
+++ b/src/Ethereum/Transaction.hs
@@ -41,8 +41,6 @@ import Data.Word
 
 import Ethereum.Utils
 
-import GHC.Natural
-
 -- internal modules
 
 import Ethereum.Misc

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -18,7 +19,10 @@ import Test.Tasty
 -- internal modules
 
 import qualified Test.Ethereum.Block
+
+#ifdef ETHHASH
 import qualified Test.Ethereum.Ethhash
+#endif
 import qualified Test.Ethereum.HP
 import qualified Test.Ethereum.RLP
 import qualified Test.Ethereum.Receipt
@@ -33,6 +37,8 @@ main = defaultMain $ testGroup "Ethereum Tests"
     , Test.Ethereum.Trie.tests
     , Test.Ethereum.Receipt.tests
     -- , Test.Ethereum.Header.tests
+#ifdef ETHHASH
     , Test.Ethereum.Ethhash.tests
+#endif
     ]
 


### PR DESCRIPTION
* temporarily place upper bound on aeson package
* use latest cabal in ci builds (3.10)
* only do CI builds for official [current stable GHC releases](https://www.haskell.org/ghc/download.html)